### PR TITLE
fix: update Carousel.svelte resize observer

### DIFF
--- a/src/components/Carousel/Carousel.svelte
+++ b/src/components/Carousel/Carousel.svelte
@@ -159,10 +159,9 @@
   let pageWindowWidth = 0
   let pageWindowElement
   let particlesContainer
+  let pageWindowElementResizeObserver
 
-  const pageWindowElementResizeObserver = createResizeObserver(({
-    width,
-  }) => {
+  const pageWindowElementResizeObserverHandler = ({ width }) => {
     pageWindowWidth = width
     data.particleWidth = pageWindowWidth / data.particlesToShow
 
@@ -171,7 +170,7 @@
       particleWidth: data.particleWidth,
     })
     methods.offsetPage({ animated: false })
-  })
+  }
 
   function addClones() {
     const {
@@ -191,6 +190,7 @@
 
   onMount(() => {
     (async () => {
+      pageWindowElementResizeObserver = createResizeObserver(pageWindowElementResizeObserverHandler)
       await tick()
       if (particlesContainer && pageWindowElement) {
         data.particlesCountWithoutClones = particlesContainer.children.length
@@ -209,7 +209,9 @@
   })
 
   onDestroy(() => {
-    pageWindowElementResizeObserver.disconnect()
+    if (pageWindowElementResizeObserver) {
+      pageWindowElementResizeObserver.disconnect()
+    }
     progressManager.reset()
   })
 


### PR DESCRIPTION
This pull request includes changes to the `src/components/Carousel/Carousel.svelte` file to improve the handling of the resize observer in the carousel component. The most important changes include refactoring the resize observer setup and cleanup to ensure proper resource management.

Refactoring resize observer handling:

* [`src/components/Carousel/Carousel.svelte`](diffhunk://#diff-610e030c860371c14a1ee7f3046dd8b76fe71de707a852a9e06485b257907269R162-R164): Changed the initialization of `pageWindowElementResizeObserver` to use a handler function instead of directly assigning it.
* [`src/components/Carousel/Carousel.svelte`](diffhunk://#diff-610e030c860371c14a1ee7f3046dd8b76fe71de707a852a9e06485b257907269R193): Moved the `pageWindowElementResizeObserver` creation to the `onMount` lifecycle method to ensure it is properly set up when the component mounts.
* [`src/components/Carousel/Carousel.svelte`](diffhunk://#diff-610e030c860371c14a1ee7f3046dd8b76fe71de707a852a9e06485b257907269R212-R214): Added a conditional check in the `onDestroy` lifecycle method to disconnect the `pageWindowElementResizeObserver` only if it exists, ensuring proper cleanup.